### PR TITLE
Add SIMD algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,12 @@ Count ones, fast (aka popcount, hamming weight). This provides a
 performant popcount and bitwise hamming distance for a slice of bytes.
 """
 
-
 [features]
 unstable = []
+simd = ["faster"]
+
+[dependencies]
+faster = { git = "https://github.com/AdamNiederer/faster", branch = "master", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 #[cfg(test)] extern crate quickcheck;
 #[cfg(test)] extern crate rand;
 #[cfg(all(test, feature = "unstable"))] extern crate test;
+#[cfg(feature = "simd")] extern crate faster;
 
 mod weight_;
 pub use weight_::weight;


### PR DESCRIPTION
Hello,

I've managed to achieve a ~2x speedup on newer Intel machines on large workloads using  `faster`, which implements Muła's fast SIMD popcount algorithms. This should also "just work" on AVX-512 with a library version bump in the future.

A few caveats:

- Performance is all over the place for short slices, so I haven't replaced the scalar algorithm.
- This will only compile on nightly for now, so I've added it behind a feature.
- This is using a pre-release version of `faster` - Leaving this open until I release 0.5.0 and bump the version in this branch is recommended.

I have some additional notes and benchmarks in the commit message. 

It's also worth nothing that this algorithm degrades nicely to the naiive algorithm if SSE3 or AVX2 isn't present, but it looks like it's a good bit faster at the asymptote because of unrolling.