### PR TITLE
Update quickcheck to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ performant popcount and bitwise hamming distance for a slice of bytes.
 unstable = []
 
 [dev-dependencies]
-quickcheck = "0.2"
-rand = "0.3"
+quickcheck = "1.0"
 criterion = "0.2"
 
 [[bench]]

--- a/src/distance_.rs
+++ b/src/distance_.rs
@@ -171,7 +171,6 @@ pub fn distance(x: &[u8], y: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use quickcheck as qc;
-    use rand;
     #[test]
     fn naive_smoke() {
         let tests: &[(&[u8], &[u8], u64)] = &[
@@ -202,7 +201,7 @@ mod tests {
             qc::TestResult::from_bool(super::distance_fast(x, y).unwrap() == super::naive(x, y))
         }
         qc::QuickCheck::new()
-            .gen(qc::StdGen::new(rand::thread_rng(), 10_000))
+            .gen(qc::Gen::new(10_000))
             .quickcheck(prop as fn(Vec<u8>,Vec<u8>,u8) -> qc::TestResult)
     }
     #[test]

--- a/src/weight_.rs
+++ b/src/weight_.rs
@@ -77,7 +77,6 @@ pub fn weight(x: &[u8]) -> u64 {
 #[cfg(test)]
 mod tests {
     use quickcheck as qc;
-    use rand;
     #[test]
     fn naive_smoke() {
         let tests = [(&[0u8] as &[u8], 0),
@@ -100,7 +99,7 @@ mod tests {
             qc::TestResult::from_bool(super::weight(data) == super::naive(data))
         }
         qc::QuickCheck::new()
-            .gen(qc::StdGen::new(rand::thread_rng(), 10_000))
+            .gen(qc::Gen::new(10_000))
             .quickcheck(prop as fn(Vec<u8>,u8) -> qc::TestResult)
     }
     #[test]


### PR DESCRIPTION
This is a complete stab in the dark as I have zero rust experience - but hopefully at least serves as a prod to update hamming to the latest quickcheck as part of an attempt to package primal for Fedora.

Also - crates.io has version 0.1.3 of hamming, but this github repo only seems to be at 0.1.2.  What is up with that?

Thanks for any help here.